### PR TITLE
PROG-78 write docs for chocolatey installer  

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ These scripts are installing essential packages to be able to develop code for [
 
 ## Dependencies
 
-You will need to install one of the following:\
-[bash](https://www.gnu.org/software/bash/) (Linux, Macos, Windows, etc.)\
+You will need to install one of the following:  
+[bash](https://www.gnu.org/software/bash/) (Linux, Macos, Windows, etc.)  
 [PowerShell](https://github.com/PowerShell/PowerShell) (Windows only, version >= 5.0)
 
 ## Installation Instructions
@@ -14,51 +14,89 @@ To install, you can either clone this repository and run the scripts directly or
 
 ### Windows 10 and 11
 
-For the Windows Command Prompt, use the `powershellInstaller.cmd` script.
-
-```cmd
-curl.exe --output install.ps1 --url https://github.com/frc-862/installers/blob/main/powershellInstaller.cmd && ./install.ps1 && del ./install.ps1
+To run the script, you are required to have Administrative permissions.  
+Start by opening powershell as an administrator.  
+Then, run
+```PowerShell
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; 
 ```
-
+and then
 ```PowerShell
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/frc-862/installers/main/powershellInstaller.ps1" -OutFile ".\install.ps1"; .\install.ps1; rm .\install.ps1
 ```
+The powershell installer has a built-in macro that automatically runs through the WPILib Installer, so you can skip past the WPILib installer window.  
+On a similar note, you should leave the computer alone while running the script, as to not mess up the macro.
 
 ### Linux, Mac OS, etc
 
-For systems with bash, use the `bashInstaller.sh` script.\
+For systems with bash, use the `bashInstaller.sh` script.  
 You may need to install `curl`. Follow [this guide](https://www.tecmint.com/install-curl-in-linux/).
 
 ```bash
 bash <(curl https://raw.githubusercontent.com/frc-862/installers/main/bashInstaller.sh)
 ```
 
-## Wpilib Install Proccess
+## WPILib Install Proccess (NOTE: Non-Windows Only)
+After the installer downloads the WPILib installer, (this can take several minutes on slower connections) a new window  launches that will look something like this:  
 
-This script downloads and runs the wpilib installer, which is not a fully automated progam.
-
-After the installer downloads the wpilib installer, (this can take several minutes on slower connections) a new windows will launch that should look something like this:\
 ![wpilib1.png](https://github.com/frc-862/installers/raw/main/assets/wpilib1.png)
 
-Press start, and you will see the vscode install screen:\
+Press start, and you will see the vscode install screen:  
 ![wpilib2.png](https://github.com/frc-862/installers/raw/main/assets/wpilib2.png)
 
 *If you already have vs code, you can press skip and move past the installation instructions.*
 
 *If you already have vs code downloaded for installation, you can select the "Use downloaded installer" option.*
 
-Otherwise, press "download vs code for single install."\
+Otherwise, press "download vs code for single install."  
 Press continue once the loading bar has finished.
 
-On the next screen, select the following options:\
+On the next screen, select the following options:  
 ![wpilib3.png](https://github.com/frc-862/installers/raw/main/assets/wpilib3.png)
 
 Press "Install for single user" to install.
 
-If nothing goes wrong, you should see a screen like this:\
+If nothing goes wrong, you should see a screen like this:  
 ![wpilib4.png](https://github.com/frc-862/installers/raw/main/assets/wpilib4.png)
 
 Press Finish, and the installer script will continue.
+
+## GPR Key
+Some of our robot projects depend on [lightning](https://github.com/frc-862/lightning), which is published on the GitHub Package Registry (we will just call this the "gpr"). Unfortunately, the gpr requires authentication to use public repositories (not sure why, or when this will change). There are instructions for how to set this up below.
+
+To begin, open settings after clicking on your profile picture.  
+![gpr1.png](https://github.com/frc-862/installers/raw/main/assets/gpr1.png)  
+Then, click on "Developer settings", near the end of the page.  
+![gpr2.png](https://github.com/frc-862/installers/raw/main/assets/gpr2.png)  
+Afterward, click on "Personal access tokens".  
+![gpr3.png](https://github.com/frc-862/installers/raw/main/assets/gpr3.png)  
+Next, click on "Generate new token" to create a token.  
+![gpr4.png](https://github.com/frc-862/installers/raw/main/assets/gpr4.png)  
+Name your token something memorable, or at least be able to identify the key.  
+For the Expiration, you can set it to expire never, but as advised by GitHub, I would set it to 30-90 days and follow these instructions again when it expires. However, it is usually fine to set it to not expire.  
+Finally, make sure to check the `write:packages` and `delete:packages` scopes (The repo scope will automagically be checked).  
+![gpr5.png](https://github.com/frc-862/installers/raw/main/assets/gpr5.png)  
+After clicking on "Generate token" at the end of the page, you will get prompted to copy the key for the token. Make sure the copy this and save it for the next steps.  
+Assuming you ran one of the install scripts, you should have a `.gradle/` folder in your home directory, (`~` for Linux, Mac OSX, and Powershell).  
+Navigate into the folder and open the file `gradle.properties` in your favorite text editor (it's ok if it's not there, just create a new file with the same name).  
+Then, add these two lines into `gradle.properties`
+
+```properties
+gpr.user=USERNAME
+gpr.key=KEY
+```
+
+Where `USERNAME` is your GitHub Username, and `KEY` is the key you got earlier.  
+Save the file and you should be able to build other repositories now. As always, feel free to make a JIRA ticket if you have any issues.
+
+## SSH Key Instructions
+
+An SSH Key is required to contribute code.
+
+Instructions to create an SSH key are located at the [GitHub Docs](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/about-ssh).  
+
+Note: Make sure to clone repositories through SSH instead of HTTPS.  
+The repository address will look something like `git@github.com:USER/REPO.git` (SSH) as opposed to `https://github.com/USER/REPO.git` (HTTPS).
 
 ## Included Packages
 
@@ -68,62 +106,15 @@ Name | Use
 [git](https://git-scm.com/) | The version control system that we use to manage all of our code.
 [openjdk11](https://openjdk.java.net/projects/jdk/11/) | The language we use to write our code.
 [WPILib (extension)](https://wpilib.org/) | An extension for Visual Studio Code that makes working on WPILib projects easier.
-[Java Extension Pack (extension)](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack) | Contains several extensions that make writing java code much easier
+[Java Extension Pack (extension)](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack) | Contains several extensions that make writing java code much easier.
 [brew (Mac)](https://brew.sh/) | A package manager that makes installing software a lot easier.
-[scoop (Windows)](https://scoop.sh/) | Another package manager that makes installing software a lot easier.
+[chocolatey (Windows)](https://chocolatey.org/) | Another package manager but for windows.
 [gradle](https://gradle.org/) | An open-source build system for java we use to manage dependencies.
+[lazygit](https://github.com/jesseduffield/lazygit) | A TUI that makes version control with git a whole lot easier.
+
 
 At the end of all the installations, the script clones the [lightning](https://github.com/frc-862/lightning) repository into `~/Documents/lightning`
 
 Finally, the script builds the lightning repository. If any errors occur feel free to make a JIRA ticket or put a note on discord, and someone will help you out.
 
 If no errors occur, you have installed all the necessary applications/packages to build FRC code
-
-## Other Things You Should Set Up
-
-Some of our robot projects depend on [lightning](https://github.com/frc-862/lightning), which is published on the GitHub Package Registry (we will just call this the "gpr"). Unfortunately, the gpr requires authentication to use public repositories (not sure why, or when this will change). There are instructions for how to set this up below.\
-Additionally, you will need to setup an ssh key to contribute code to our repositories. You can also find instructions for setting this up below.
-
-### GPR Key Instructions
-
-To begin, open settings after clicking on your profile picture.\
-![gpr1.png](https://github.com/frc-862/installers/raw/main/assets/gpr1.png)\
-Then, click on "Developer settings", near the end of the page.\
-![gpr2.png](https://github.com/frc-862/installers/raw/main/assets/gpr2.png)\
-Afterward, click on "Personal access tokens".\
-![gpr3.png](https://github.com/frc-862/installers/raw/main/assets/gpr3.png)\
-Next, click on "Generate new token" to create a token.\
-![gpr4.png](https://github.com/frc-862/installers/raw/main/assets/gpr4.png)\
-Name your token something memorable, or at least be able to identify the key.\
-For the Expiration, you can set it to expire never, but as advised by GitHub, I would set it to 30-90 days and follow these instructions again when it expires. However, it is usually fine to set it to not expire.\
-Finally, make sure to check the `write:packages` and `delete:packages` scopes (The repo scope will automagically be checked).\
-![gpr5.png](https://github.com/frc-862/installers/raw/main/assets/gpr5.png)\
-After clicking on "Generate token" at the end of the page, you will get prompted to copy the key for the token. Make sure the copy this and save it for the next steps.\
-Assuming you ran one of the install scripts, you should have a `.gradle/` folder in your home directory, (`~` for Linux, Mac OSX, and Powershell).\
-Navigate into the folder and open the file `gradle.properties` in your favorite text editor (it's ok if it's not there, just create a new file with the same name).\
-Then, add these two lines into `gradle.properties`
-
-```properties
-gpr.user=USERNAME
-gpr.key=KEY
-```
-
-Where `USERNAME` is your GitHub Username, and `KEY` is the key you got earlier.\
-Save the file and you should be able to build other repositories now. As always, feel free to make a JIRA ticket if you have any issues.
-
-### SSH Key Instructions
-
-An SSH Key is required to contribute code.
-
-Instructions to create an SSH key are located at the [GitHub Docs](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/about-ssh).  
-
-Note: Make sure to clone repositories through SSH instead of HTTPS.\
-The repository address will look something like `git@github.com:USER/REPO.git` (SSH) as opposed to `https://github.com/USER/REPO.git` (HTTPS).
-
-## Driver Station (Windows Only)
-
-There's a video on installing the Driver Station and other relevant tools [here](https://drive.google.com/file/d/161bp7iFEciRYEJMP1MONmpF_pKdheI-W/view).
-
-The link to the NI Tool Suite installer can be found [here](https://www.ni.com/en-us/support/downloads/drivers/download.frc-game-tools.html#369633).
-
-These tools are only built for Windows machines.

--- a/powershellInstaller.ps1
+++ b/powershellInstaller.ps1
@@ -1,7 +1,6 @@
 #Install Chocolatey
 Write-Host "Installing Chocolatey..." -ForegroundColor Green
-Set-ExecutionPolicy Bypass -Scope Process -Force
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+
 Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
 #Install specified packages, in order


### PR DESCRIPTION
switch \ for double space, switch to choco, rearrange sections, remove ni-tools installation instructions, wpilib install is automated now

\ for double space: easier to read
choco: originally scoop
sections: didn't make a lot of sense before, installation now much smoother
ni-tools instructions removal: it's only for windows, and it's automated now
wpilib install: also automated